### PR TITLE
Fix lint errors

### DIFF
--- a/greeks/base.py
+++ b/greeks/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import tributary.lazy as tl
 
@@ -7,7 +7,7 @@ _ENV_CONTEXT = None
 
 class Env(tl.LazyGraph):
     def __init__(self, now=None):
-        self._now = now or datetime.now()
+        self._now = now or datetime.now(UTC)
 
     def now(self):
         return self._now

--- a/greeks/tests/test_all.py
+++ b/greeks/tests/test_all.py
@@ -1,4 +1,4 @@
-from greeks import *  # noqa
+from greeks import *
 
 
 def test_all():


### PR DESCRIPTION
Updates code for the latest Ruff diagnostics without changing lint configuration. `make lint` passes.